### PR TITLE
feat: Dockerize frontend and add docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    command: python manage.py runserver 0.0.0.0:8000
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.env
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-bookworm-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Changes
- Added `frontend/Dockerfile` (Node 22) and `.dockerignore`.
- Created root `docker-compose.yml` to orchestrate both services.
- Exposed frontend on port `5173`.

## Verification
1. Run `docker compose up --build`
2. Open `http://localhost:5173` (Frontend should load)
3. Open `http://localhost:8000/api/` (Backend should respond 404/json)

Closes #35